### PR TITLE
Add check for canceled request in Axios useEffect

### DIFF
--- a/src/components/Users.js
+++ b/src/components/Users.js
@@ -20,8 +20,10 @@ const Users = () => {
                 console.log(response.data);
                 isMounted && setUsers(response.data);
             } catch (err) {
-                console.error(err);
-                navigate('/login', { state: { from: location }, replace: true });
+                if (err.name !== "CanceledError") {
+                    console.error(err);
+                    navigate('/login', { state: { from: location }, replace: true });
+                }
             }
         }
 
@@ -31,7 +33,7 @@ const Users = () => {
             isMounted = false;
             controller.abort();
         }
-    }, [])
+    }, [axiosPrivate, isLoading, navigate, location])
 
     return (
         <article>


### PR DESCRIPTION
When the `useEffect()` runs in dev environments, it actually runs twice. This can cause the abort controller to interrupt the operation and gets caught by the `catch` on line 22 causing the user to be routed to the login page. Adding an `if` statement and checking the `err.name` attribute prevents the catch from calling `navigate`. I also added `axiosPrivate`, `isLoading`, `navigate`, and `location` to the dependency array since they are defined outside the useEffect and it was causing the following warning:

```React Hook useEffect has missing dependencies: 'axiosPrivate', 'location', 'navigate' and 'location'. Either include them or remove the dependency array  react-hooks/exhaustive-deps.```

Now with these changes, I can set isLoading to true and force a re-render and fetch of the data, such as when closing out a modal or other user driven action that might want to cause a refresh of the data.